### PR TITLE
update moment package version to latest minor

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"version": "0.0.1",
 	"dependencies": {
 		"express": "^4.14.0",
-		"moment" : "~2.10.2"
+		"moment" : "^2.10.2"
 	},
 	"main": "server.js",
 	"scripts": {


### PR DESCRIPTION
- [x] Use the caret (`^`) to prefix the version of moment in your dependencies and allow npm to update it to any new MINOR release.